### PR TITLE
Upgrade asciidoctorj to 1.5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target/
 .DS_Store
 .java-version
 dependency-reduced-pom.xml
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
         <maven.apache-rat-plugin.version>0.7</maven.apache-rat-plugin.version>
         <maven.jacoco-maven-plugin.version>0.7.2.201409121644</maven.jacoco-maven-plugin.version>
 
-        <asciidoctor.version>1.5.4</asciidoctor.version>
+        <asciidoctor.version>1.5.5</asciidoctor.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
         <ant.version>1.8.0</ant.version>
-        <jruby.version>1.7.21</jruby.version>
+        <jruby.version>1.7.26</jruby.version>
         <slf4j.version>1.7.5</slf4j.version>
         <commons-io.version>2.4</commons-io.version>
 
@@ -94,10 +94,10 @@
             <version>${asciidoctorj-pdf.version}</version>
         </dependency>
         <dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-nop</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>


### PR DESCRIPTION
Hi @binout ,

We are encountering this issue https://github.com/asciidoctor/asciidoctorj/issues/472 and we would like to have an asciidoctor-ant version upgraded to 1.5.5. We need it for an extension developed for https://github.com/beanvalidation/beanvalidation-spec.

Could you integrate this PR and release a new version?

I saw in https://github.com/asciidoctor/asciidoctor-ant/issues/52 that you were thinking about adding new dependencies but I think a quick release with the latest asciidoctorj would be nice. Other dependencies can still be added later.

Thanks!