### PR TITLE
Upgrade to Asciidoctor 1.6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-  - openjdk6
 install:
   - mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoctor-ant</artifactId>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
     <name>asciidoctor-ant</name>
@@ -59,10 +59,10 @@
         <maven.apache-rat-plugin.version>0.7</maven.apache-rat-plugin.version>
         <maven.jacoco-maven-plugin.version>0.7.2.201409121644</maven.jacoco-maven-plugin.version>
 
-        <asciidoctorj.version>1.5.5</asciidoctorj.version>
-        <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
+        <asciidoctorj.version>1.6.0-alpha.3</asciidoctorj.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
         <ant.version>1.8.0</ant.version>
-        <jruby.version>1.7.26</jruby.version>
+        <jruby.version>9.1.8.0</jruby.version>
         <commons-io.version>2.4</commons-io.version>
 
         <junit.version>4.11</junit.version>
@@ -88,6 +88,12 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
             <version>${asciidoctorj.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jruby</groupId>
+                    <artifactId>jruby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>

--- a/src/test/java/org/asciidoctor/ant/extensions/TwitterMacro.java
+++ b/src/test/java/org/asciidoctor/ant/extensions/TwitterMacro.java
@@ -15,8 +15,8 @@
  */
 package org.asciidoctor.ant.extensions;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.Inline;
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
 import org.asciidoctor.extension.InlineMacroProcessor;
 
 import java.util.HashMap;
@@ -24,19 +24,23 @@ import java.util.Map;
 
 public class TwitterMacro extends InlineMacroProcessor {
 
+    public TwitterMacro(String macroName) {
+        super(macroName);
+    }
+
     public TwitterMacro(String macroName, Map<String, Object> config) {
         super(macroName, config);
     }
 
     @Override
-    protected Object process(AbstractBlock parent, String twitterHandle, Map<String, Object> attributes) {
+    public Object process(ContentNode parent, String twitterHandle, Map<String, Object> attributes) {
         // Define options for an 'anchor' element.
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type",":link");
         options.put("target", "http://www.twitter.com/@"+twitterHandle);
 
         // Prepend twitterHandle with @ as text link.
-        final Inline inlineTwitterLink = createInline(parent, "anchor", "@"+twitterHandle, attributes, options);
+        final PhraseNode inlineTwitterLink = createPhraseNode(parent, "anchor", "@"+twitterHandle, attributes, options);
 
         // Convert to String value.
         return inlineTwitterLink.convert();


### PR DESCRIPTION
Hi @binout ,

It turns out that Asciidoctor 1.6 changed a bit how the initialization is done. So while the new core artifact should solve the issue of a minor upgrade, we still need a branch for the 1.6.x upgrade.

I did the work to upgrade to 1.6 (the PR is against master but it should be put in a specific branch).

Do you think we could merge this to a 1.6.x branch and release a parallel 1.6.0-alpha.3 release while you're at it?

It would be greatly appreciated!

Thanks!
