### PR TITLE
Update TravisCi to Trusty:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-language: java
+dist: trusty
 sudo: false
+language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
-  - openjdk6
 install:
   - mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:


### PR DESCRIPTION
Summary:
TravisCI launched a new Ubuntu distro for Linux build and settings need to be updated

PR includes:
- Set distribution to Trusty
- Adds openjdk8
- Removes oraclejdk7
- Remove Java6: not available and not compatible with Maven 3.5.0 and AsciidoctorJ 1.5.6.

Long story here:
https://github.com/asciidoctor/asciidoctorj/issues/575

Here we discuss with @mojavelinux about dropping support for Java6
https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/309
I am not sure if it is in the scope of the Ant plugin to also drop support for 6, but seems quite reasonable. Let's discuss it anyway :smile: 
